### PR TITLE
Fix LD_AUDIT core dump (removed non-audit payload)

### DIFF
--- a/headcrab.sh
+++ b/headcrab.sh
@@ -572,14 +572,14 @@ set -eu
     | grep "SLSsteam-Any.7z" \
     | cut -d '"' -f 4) &> /dev/null
     }
-    
+
     export_sls(){
         if [ -d "$FlatpakSteamInstallDir" ]; then
                 copySLSsteam
-                LD_AUDIT=$HOME/.var/app/com.valvesoftware.Steam/.local/share/SLSsteam/library-inject.so:$HOME/.var/app/com.valvesoftware.Steam/.local/share/SLSsteam/SLSsteam.so "$@"
+                LD_AUDIT=$HOME/.var/app/com.valvesoftware.Steam/.local/share/SLSsteam/library-inject.so "$@"
         else
                 copySLSsteam
-                LD_AUDIT=$HOME/.local/share/SLSsteam/library-inject.so:$HOME/.local/share/SLSsteam/SLSsteam.so "$@"
+                LD_AUDIT=$HOME/.local/share/SLSsteam/library-inject.so "$@"
         fi
                 echo &> /dev/null
                 }


### PR DESCRIPTION
Hey, steam kept crashing with core dump right after headcrba injection on my steamdeck.
I looked into the script and noticed `export_sls` passes both `library-inject.so` and `SLSsteam.so` to `LD_AUDIT`. 
Sinse `SLSsteam.so` isn't actual audit interface, it makes `ld.so` crash. 
I just removed `SLSsteam.so` from it so it only passes the injector, and steam boots up perfectly fine now, showing SLS sucessful loading message.
Hope this helps to fix it.