### PR TITLE
Update headcrab.sh

### DIFF
--- a/headcrab.sh
+++ b/headcrab.sh
@@ -2,7 +2,7 @@
 
 
     #Headcrab Compatibile Client Version
-    HeadcrabCompatibleClientVer=1782866176
+    HeadcrabCompatibleClientVer=1784669098
     
     #Paths
     SCRIPT_DIR="$(dirname "$(realpath "$0")")"


### PR DESCRIPTION
## Summary
- Bumps `HeadcrabCompatibleClientVer` to `1784669098` (current steamdeck_stable build).

## Test plan
- [x] Verified against a live Steam Deck running build 1784669098.