### PR TITLE
Keep SLSsteam config in sync

### DIFF
--- a/headcrab.sh
+++ b/headcrab.sh
@@ -564,6 +564,118 @@
             fi
                 echo "" &> /dev/null
             }
+
+    updateSLSsteamConfig(){
+        (
+            local latest_config="$1"
+            local config_file
+            local merged_config
+            local backup_base
+            local backup
+            local suffix=1
+
+            if [ ! -f "$latest_config" ]; then
+                return
+            fi
+
+            whereSLSsteamconfig
+            config_file="$PWD/config.yaml"
+
+            if [ ! -f "$config_file" ]; then
+                return
+            fi
+
+            if ! grep -q '^DisableFamilyShareLock:' "$latest_config"; then
+                echo "SLSsteam Config Template Is Invalid"
+                return
+            fi
+
+            merged_config=$(mktemp "${config_file}.tmp.XXXXXX") || return
+
+            if ! awk '
+                NR == FNR {
+                    if ($0 ~ /^[A-Za-z_][A-Za-z0-9_]*:/) {
+                        key = $0
+                        sub(/:.*/, "", key)
+                        current = key
+                        present[key] = 1
+                        saved[key] = $0 ORS
+                        next
+                    }
+
+                    if (current != "" && $0 ~ /^[[:space:]]+/) {
+                        saved[current] = saved[current] $0 ORS
+                    }
+                    next
+                }
+
+                /^[A-Za-z_][A-Za-z0-9_]*:/ {
+                    key = $0
+                    sub(/:.*/, "", key)
+
+                    printf "%s", prefix
+                    prefix = ""
+
+                    if (key in present) {
+                        printf "%s", saved[key]
+                        use_template = 0
+                    } else {
+                        print
+                        use_template = 1
+                    }
+
+                    have_key = 1
+                    next
+                }
+
+                have_key && /^[[:space:]]+/ {
+                    if (use_template) {
+                        print
+                    }
+                    next
+                }
+
+                {
+                    prefix = prefix $0 ORS
+                }
+
+                END {
+                    printf "%s", prefix
+                }
+            ' "$config_file" "$latest_config" > "$merged_config"; then
+                echo "SLSsteam Config Update Failed"
+                rm -f "$merged_config"
+                return
+            fi
+
+            if ! grep -q '^DisableFamilyShareLock:' "$merged_config"; then
+                echo "SLSsteam Config Update Failed"
+                rm -f "$merged_config"
+                return
+            fi
+
+            if cmp -s "$config_file" "$merged_config"; then
+                echo "SLSsteam Config Is Up To Date"
+                rm -f "$merged_config"
+                return
+            fi
+
+            backup_base="${config_file}.headcrab-$(date +%Y%m%d-%H%M%S)"
+            backup="$backup_base"
+
+            while [ -e "$backup" ]; do
+                backup="${backup_base}-${suffix}"
+                suffix=$((suffix + 1))
+            done
+
+            cp -a "$config_file" "$backup"
+            chmod --reference="$config_file" "$merged_config" 2>/dev/null || true
+            mv -f "$merged_config" "$config_file"
+
+            echo "SLSsteam Config Updated"
+            echo "Config Backup: $backup"
+        )
+    }
             
     overideupdate(){
         echo "the headcrab latches on the steam process.."
@@ -641,6 +753,7 @@
 		downloadnetsock
         downloadSLSsteam
          7z x $SCRIPT_DIR/SLSsteam_Download/SLSsteam-Any.7z -aoa > /dev/null
+         updateSLSsteamConfig "$SCRIPT_DIR/SLSsteam_Download/res/config.yaml"
          rm -rf tools
          rm -rf res
          rm setup.sh


### PR DESCRIPTION
Headcrab replaces SLSsteam, but an existing config can still be left on an older format. That can leave new options missing and old ones hanging around.

This updates the existing config using the one included with the downloaded SLSsteam release. Existing values and app lists are kept, missing options are added, removed top level options are dropped, and the old config is backed up first. If the config is already current, it leaves it alone.

Tested with native Steam and on a CachyOS handheld. Existing settings and app lists were preserved, backups were created, and SLSsteam loaded normally after both installs.